### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author='Holger Drewes',
     author_email='Holger.Drewes@gmail.com',
     url='https://github.com/holgerd77/django-dynamic-scraper/',
-    long_description=open(os.path.join(os.path.dirname(__file__), 'README.rst')).read(),
+    long_description=open(os.path.join(os.path.dirname(__file__), 'README.rst'), encoding="UTF-8").read(),
     license='BSD License',
     platforms=['OS Independent'],
     packages=[


### PR DESCRIPTION
bug fix for python3, file open backpoint

Traceback (most recent call last):
  File "setup.py", line 12, in <module>
    long_description=open(os.path.join(os.path.dirname(__file__), 'README.rst')).read(),
  File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1097: ordinal not in range(128)